### PR TITLE
Enable deployment via GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A GitHub Action to deploy to Firebase for Node18.
 - Make sure that you checkout the repository using the [actions/checkout](https://github.com/actions/checkout) action
 - Make sure that you have the `firebase.json` file in the repository
 - To obtain the Firebase token, run `firebase login:ci` on your local computer and [store the token](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) as the `FIREBASE_TOKEN` secret
+- To obtain service account credentials, get the service account JSON file from Firebase console and set its path to `GOOGLE_APPLICATION_CREDENTIALS`
+- Either `FIREBASE_TOKEN` or `GOOGLE_APPLICATION_CREDENTIALS` are required to deploy the project. No need to set both at the same time.
 - Specify the Firebase project name in the `FIREBASE_PROJECT` env var
 
 ## Workflow examples

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,8 @@ npm install
 
 cd functions; npm install
 
-if [ -z "${FIREBASE_TOKEN}" ]; then
-    echo "FIREBASE_TOKEN is missing"
+if [[ -z "${FIREBASE_TOKEN}" && -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
+    echo "Access tokens are missing! Provide either FIREBASE_TOKEN or GOOGLE_APPLICATION_CREDENTIALS"
     exit 1
 fi
 


### PR DESCRIPTION
This PR adds a validation check to allow deployment either via FIREBASE_TOKEN or GOOGLE_APPLICATION_CREDENTIALS.