### PR TITLE
Add functions only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A GitHub Action to deploy to Firebase for Node18.
 - To obtain the Firebase token, run `firebase login:ci` on your local computer and [store the token](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) as the `FIREBASE_TOKEN` secret
 - To obtain service account credentials, get the service account JSON file from Firebase console and set its path to `GOOGLE_APPLICATION_CREDENTIALS`
 - Either `FIREBASE_TOKEN` or `GOOGLE_APPLICATION_CREDENTIALS` are required to deploy the project. No need to set both at the same time.
-- Specify the Firebase project name in the `FIREBASE_PROJECT` env var
+- Specify the Firebase project name in the `FIREBASE_PROJECT` env var.
+- By default, the action will deploy all firebase components. If you just want to deploy the functions, set `FUNCTIONS_ONLY` env var to any value.
 
 ## Workflow examples
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,3 +21,4 @@ firebase experiments:enable webframeworks
 firebase deploy \
     -m "${GITHUB_REF} (${GITHUB_SHA})" \
     --project ${FIREBASE_PROJECT} \
+    ${FUNCTIONS_ONLY:+--only functions}


### PR DESCRIPTION
This PR allows deployment of firebase functions only if `FUNCTIONS_ONLY` environment variable is set.